### PR TITLE
Added very (blazingly) fast implementation (🦀)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 .idea/
 venv/
+tmp.mbox
+tmp_py.txt
+tmp_rs.txt
+
+# Cargo stuff
+debug/
+target/
+Cargo.lock
+**/*.rs.bk
+*.pdb

--- a/rust-btw/Cargo.toml
+++ b/rust-btw/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "rust-btw"
+version = "0.1.0"
+edition = "2021"

--- a/rust-btw/src/main.rs
+++ b/rust-btw/src/main.rs
@@ -1,0 +1,136 @@
+use std::{borrow::Cow, collections::HashMap, fs::read_to_string};
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+
+    if args.len() <= 1 {
+        panic!("Please provide the path to the file as the first argument")
+    }
+
+    let path = &args[1];
+
+    let contents = read_to_string(path).unwrap_or_else(|_| panic!("File '{path}' not found"));
+
+    let res = parse(&contents);
+
+    println!("{res}");
+}
+
+fn parse(contents: &str) -> String {
+    let mut map = HashMap::<&str, Vec<&str>>::new();
+
+    let lines = contents.lines().enumerate().collect::<Vec<_>>();
+    let mut relevant_lines: Vec<Cow<str>> = vec![];
+
+    for (index, line) in &lines {
+        if line.starts_with("From:") {
+            let (_, next_line) = &lines[index + 1];
+
+            // For whatever reason, some emails are written one line later
+            if next_line.starts_with('\t') || next_line.starts_with(' ') {
+                let combined = (*line).to_string() + &next_line.replacen('\t', " ", 1);
+                relevant_lines.push(Cow::Owned(combined));
+            } else {
+                relevant_lines.push(Cow::Borrowed(*line));
+            }
+        }
+    }
+
+    for line in &relevant_lines {
+        if let Some((domain, address)) = parse_line(line) {
+            let entry = map.get_mut(domain);
+
+            match entry {
+                Some(entry) => {
+                    if !entry.contains(&address) {
+                        entry.push(address)
+                    }
+                }
+                None => {
+                    let _ = map.insert(domain, vec![address]);
+                }
+            };
+        }
+    }
+
+    let mut res = String::new();
+    map.keys().for_each(|key| {
+        res.push_str(key);
+        res.push('\n');
+
+        let addresses = map.get(key).unwrap();
+
+        for address in addresses {
+            res.push('\t');
+            res.push_str(address);
+            res.push('\n');
+        }
+    });
+
+    res
+}
+
+/// I will not document this so it looks more mysterious
+fn parse_line(input: &str) -> Option<(&str, &str)> {
+    if let Some(mid) = input.find(" <") {
+        let relevant = &input[mid + 2..input.trim().len() - 1];
+        let split = relevant.find('@').unwrap();
+        return Some((&relevant[split + 1..], relevant));
+    } else if let Some(mid) = input.find('@') {
+        return Some((&input[mid + 1..], (input["From:".len()..].trim())));
+    }
+
+    None
+}
+
+/// The two tests here are made to compare the outputs of the rust and python versions of the
+/// project. To run these, 2 files must be created inside the `rust-btw` folder, `tmp_py.txt`
+/// and `tmp_rs.txt` containing the output of the python and rust code respectively.
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_py_not_contained_in_rs() {
+        let contents_py = include_str!("../tmp_py.txt");
+        let contents_rs = include_str!("../tmp_rs.txt");
+
+        let lines_py = contents_py.trim().lines().collect::<Vec<_>>();
+
+        let lines_rs = contents_rs
+            .trim()
+            .lines()
+            .map(|l| l.to_lowercase())
+            .collect::<Vec<_>>();
+
+        let mut py_not_contained_in_rs = vec![];
+        for py_line in lines_py {
+            if !lines_rs.contains(&py_line.to_string()) {
+                py_not_contained_in_rs.push(py_line);
+            }
+        }
+
+        assert_eq!(py_not_contained_in_rs.len(), 0, "{:?}", py_not_contained_in_rs);
+    }
+
+    #[test]
+    fn test_rs_not_contained_in_py() {
+        let contents_py = include_str!("../tmp_py.txt");
+        let contents_rs = include_str!("../tmp_rs.txt");
+
+        let lines_py = contents_py.trim().lines().collect::<Vec<_>>();
+
+        let lines_rs = contents_rs
+            .trim()
+            .lines()
+            .map(|l| l.to_lowercase())
+            .collect::<Vec<_>>();
+
+        let mut rs_not_contained_in_py = vec![];
+        for rs_line in lines_rs {
+            if !lines_py.contains(&rs_line.as_str()) {
+                rs_not_contained_in_py.push(rs_line);
+            }
+        }
+
+        assert_eq!(rs_not_contained_in_py.len(), 0, "{:?}", rs_not_contained_in_py);
+    }
+}


### PR DESCRIPTION
Following the extensive discussion outlined in #2, I decided to implement the issue.

## Benchmarks

- Python
  - probably very slow 👎
  - p*thon 🤮
  - p*thon for loops 🤮🤮
- Rust
  - rust
  - 🦀
  - (probably) blazingly fast 🚀
  - written in rust (by the way) (btw)

## Bit more seriously

There weren't many libraries for parsing mbox files so I did that myself. I tested it in my gmail archive which was 2GB and the only place it falls short compared to the python version is some cases which look like this

```
From: =?utf-8?Q?=CE=9D=CE=99=CE=9A=CE=9F=CE=9B=CE=91=CE=9F=CE=A3_=CE=9C?=
 =?utf-8?Q?=CE=A0=CE=91=CE=A1=CE=9F=CE=A4=CE=A3=CE=97=CE=A3_=CE=BC=CE?=
 =?utf-8?Q?=AD=CF=83=CF=89_=CF=84=CE=B7=CF=82_=CF=85=CF=80=CE=B7=CF=81?=
 =?utf-8?Q?=CE=B5=CF=83=CE=AF=CE=B1=CF=82_=CF=86=CF=89=CE=BD=CE=B7=CF?=
 =?utf-8?Q?=84=CE=B9=CE=BA=CE=BF=CF=8D_=CF=84=CE=B1=CF=87=CF=85=CE=B4?=
 =?utf-8?Q?=CF=81=CE=BF=CE=BC=CE=B5=CE=AF=CE=BF=CF=85?=
 <sbvmsvc9@microsoft.com>
```

where I was too lazy to make the parsing work so I just skipped it, in the entire file, there were 2 instances of this (both from Microsoft) so this doesn't seem like a big deal.

On the other hand, somewhat surprisingly, the rust version detected around 20 more emails than the python version somehow.  Some make sense and I'm not sure why they aren't in the python version but some straight up just look weird

```
From: d2lsupport@tudelft.brightspace.com <d2lsupport@tudelft.brightspace.co=
m>
```

this for example should not be split over multiple lines but here we are, the python version completely ignores it (as it is technically broken) and the rust one prints `d2lsupport@tudelft.brightspace.co`. I did not read through [the RFC](https://www.rfc-editor.org/rfc/rfc2822#section-3.4) long enough to figure out if newlines are permitted in the `addr-spec` element 😎

But anyway, the inconsistencies were in 20 out of the 1200 total entries so *for the most part* it's fine, you might get some extra junk here and there and, except for whatever that long thing Microsoft used, I at least didn't get anything less in my data file. I've also added a test that essentially diffs the python and rust outputs in case you're interested 👍